### PR TITLE
removed sudo docker in the deployment stage of FinalJenkinsfile

### DIFF
--- a/FinalJenkinsfile
+++ b/FinalJenkinsfile
@@ -27,7 +27,7 @@ pipeline {
      stage('Deploy') {
             steps {
                 script{
-                    sh 'sudo docker run -itd --name My-project-con -p 8089:80 akshu20791/myprojectnew:v1'
+                    sh 'docker run -itd --name My-project-con -p 8089:80 akshu20791/myprojectnew:v1'
                        }
                     }
                 }


### PR DESCRIPTION
Sudo docker not required to run the docker container because jenkins user already added to docker group. So, later we don't required to give sudo access to jenkins user at the time of deployment